### PR TITLE
Compatibility with RethinkDB v1.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ r.connect( //...
 // Make a query to get a cursor
 r.table('myTable').run(connection, function(err, cursor) {
   var stream = new CursorStream(cursor);
-  cursor.pipe(//... do whatever you want with your stream !
+  stream.pipe(//... do whatever you want with your stream !
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -16,12 +16,12 @@ function CursorStream(cursor) {
 }
 
 CursorStream.prototype._read = function read() {
-  if (!(this._cursor && this._cursor.hasNext())) {
-    this.push(null);
-    return;
-  }
   this._cursor.next(function (err, item) {
     if (err) {
+      if (((err.name === "RqlDriverError") && err.message === "No more rows in the cursor.")) {
+        this.push(null);
+        return;
+      }
       this.emit('error', err);
       return;
     }


### PR DESCRIPTION
hasNext() was removed in [v1.13](https://github.com/rethinkdb/rethinkdb/releases/tag/v1.13.0), so current documentation [suggests](http://rethinkdb.com/api/javascript/next/) to check `err.name` and `err.message` (eww).

also fixed typo in readme!
